### PR TITLE
removing extra time-consuming parse calls

### DIFF
--- a/src/merge-media.js
+++ b/src/merge-media.js
@@ -64,7 +64,6 @@ var updateMediaRelations = function(zip, count, _media) {
 var updateMediaContent = function(zip, count, _media) {
 
     var xmlString = zip.file("word/document.xml").asText();
-    var xml = new DOMParser().parseFromString(xmlString, 'text/xml');
 
     xmlString = xmlString.replace(new RegExp(_media[count].oldRelID + '"', 'g'), _media[count].oldRelID + '_' + count + '"');
 

--- a/src/merge-styles.js
+++ b/src/merge-styles.js
@@ -68,7 +68,6 @@ var updateStyleRel_Content = function(zip, fileIndex, styleId) {
 
 
     var xmlString = zip.file("word/document.xml").asText();
-    var xml = new DOMParser().parseFromString(xmlString, 'text/xml');
 
     xmlString = xmlString.replace(new RegExp('w:val="' + styleId + '"', 'g'), 'w:val="' + styleId + '_' + fileIndex + '"');
 


### PR DESCRIPTION
These DOMParser lines are extraneous and can cause major slowdowns in larger documents. Just removing the two in this PR.